### PR TITLE
Add mcp-wordpress server

### DIFF
--- a/servers/mcp-wordpress/server.yaml
+++ b/servers/mcp-wordpress/server.yaml
@@ -1,0 +1,50 @@
+name: mcp-wordpress
+image: mcp/mcp-wordpress
+type: server
+meta:
+  category: productivity
+  tags:
+    - wordpress
+    - blogging
+    - cms
+about:
+  title: WordPress MCP Server
+  description: |
+    The WordPress MCP Server provides a bridge between AI assistants and WordPress sites through the Model Context Protocol.  
+    Manage posts, pages and plugins across multiple WordPress installations using natural language.  
+    Supports several authentication methods (application passwords, JWT, OAuth and cookie authentication), multi‑site management, intelligent caching and real‑time monitoring.
+  icon: https://raw.githubusercontent.com/docdyhr/mcp-wordpress/main/images/wordpress-mcp-logo.png
+source:
+  project: https://github.com/docdyhr/mcp-wordpress
+config:
+  description: Configure the connection to your WordPress site(s)
+  secrets:
+    - name: mcp-wordpress.app_password
+      env: WORDPRESS_APP_PASSWORD
+      example: xxxx xxxx xxxx xxxx xxxx xxxx
+  env:
+    - name: WORDPRESS_SITE_URL
+      example: https://myblog.com
+      value: '{{mcp-wordpress.site_url}}'
+    - name: WORDPRESS_USERNAME
+      example: admin
+      value: '{{mcp-wordpress.username}}'
+    - name: WORDPRESS_AUTH_METHOD
+      example: app-password
+      value: '{{mcp-wordpress.auth_method}}'
+  parameters:
+    type: object
+    properties:
+      site_url:
+        type: string
+        description: Base URL of your WordPress site
+      username:
+        type: string
+        description: Username used to authenticate with WordPress
+      auth_method:
+        type: string
+        description: Authentication method to use (app-password, jwt, oauth, cookie)
+        default: app-password
+    required:
+      - site_url
+      - username


### PR DESCRIPTION
---
name: Add a new MCP server
about: Requests for adding a new MCP server to the Docker Catalog
title: "Add mcp-wordpress server"
labels: submission
assignees: ""
---

## MCP Server Information

**Server Name:** mcp-wordpress  
**Repository URL:** https://github.com/docdyhr/mcp-wordpress  
**Brief Description:** The WordPress MCP Server provides AI assistants with direct management of WordPress sites through the Model Context Protocol. Manage posts, pages and plugins using natural language. Supports multiple authentication methods (application passwords, JWT, OAuth and cookie auth), multi‑site management, intelligent caching and real‑time monitoring.

## Basic Requirements

- [x] **Open Source**: Licensed under the permissive MIT license  
- [x] **MCP Compliant**: Implements the MCP API specification  
- [x] **Active Development**: Recent commits and active maintainers  
- [x] **User Experience**: Provides 59 tools, multi‑site support and comprehensive documentation  
- [x] **Security**: Includes intelligent caching, rate limiting and security audits  
- [x] **Community**: Growing user base and active engagement

## Summary by Sourcery

Add a new MCP server for WordPress by introducing a server.yaml manifest that includes metadata, source repository, connection config, secrets, and parameters for authentication and site management.

New Features:
- Add mcp-wordpress MCP server specification to the catalog with metadata, description, and icon
- Define configuration schema for connecting to WordPress sites including authentication methods, site URL, and credentials